### PR TITLE
provide example for key generation

### DIFF
--- a/certomancer/registry/keys.py
+++ b/certomancer/registry/keys.py
@@ -75,7 +75,11 @@ class KeyFromFile:
                 else:
                     private, public = load_private_key(key_bytes, self.password)
             except Exception as e:
-                raise IOError(f"Failed to load key in {self.path}") from e
+                raise IOError(
+                    f"Failed to load key in {self.path}.\nGenerate one with "
+                    f"`openssl genrsa -out {repr(self.path)}` (RSA example) "
+                    f"or another appropriate tool."
+                ) from e
             self._key = AsymKey(public=public, private=private)
 
     @property


### PR DESCRIPTION
Feel free to modify as needed. Not sure about the `-m PEM` part because man page for ssh-keygen said it is a legacy format and suggested RFC4716.

Found this command on the internet and it worked for me. I did not investigate further.