### PR TITLE
Reinstate asn1crypto registration of AA types

### DIFF
--- a/certomancer/_asn1_types.py
+++ b/certomancer/_asn1_types.py
@@ -35,3 +35,25 @@ class AAControls(core.Sequence):
         ('excluded_attrs', AttrSpec, {'optional': True, 'implicit': 1}),
         ('permit_unspecified', core.Boolean, {'default': True})
     ]
+
+
+def register_extensions():
+    # patch in attribute certificate extensions
+    # Note: we only make these patches so that we can reliably produce the
+    # relevant values, and don't insist on supplying Certomancer's internal
+    # definitions at the Python level if some other library already supplied
+    # them
+    ext_map = x509.ExtensionId._map
+    ext_specs = x509.Extension._oid_specs
+    if '2.5.29.55' not in ext_map:
+        ext_map['2.5.29.55'] = 'target_information'
+        ext_specs['target_information'] = SequenceOfTargets
+    if '2.5.29.56' not in ext_map:
+        ext_map['2.5.29.56'] = 'no_rev_avail'
+        ext_specs['no_rev_avail'] = core.Null
+    if '1.3.6.1.5.5.7.1.6' not in ext_map:
+        ext_map['1.3.6.1.5.5.7.1.6'] = 'aa_controls'
+        ext_specs['aa_controls'] = AAControls
+
+
+register_extensions()

--- a/certomancer/cli.py
+++ b/certomancer/cli.py
@@ -14,9 +14,14 @@ from .crypto_utils import pyca_cryptography_present
 from .registry import CertomancerConfig, CertLabel, ServiceLabel
 from .services import CertomancerServiceError
 from .version import __version__
+from ._asn1_types import register_extensions
 
 DEFAULT_CONFIG_FILE = 'certomancer.yml'
 logger = logging.getLogger(__name__)
+
+# This is a no-op since the registration happens automatically,
+# but explicit is better than implicit
+register_extensions()
 
 
 def _log_config():


### PR DESCRIPTION
Some extension registrations were inadvertently removed in the process of upgrading asn1crypto and the removal of associated monkey patches (see 87aaf7f). This issue went undetected in the tests because our test
suite imports `pyhanko_certvalidator`, which performs the same registrations on import.

This commit restores the registration hook and makes sure it gets called when the CLI is loaded.

Fixes #4.