### PR TITLE
AIO test upgrades

### DIFF
--- a/.github/workflows/pytest-multiver.yml
+++ b/.github/workflows/pytest-multiver.yml
@@ -2,7 +2,7 @@ name: pytest
 
 on:
   push:
-    branches: [ master, "feature/*" ]
+    branches: [ master, "feature/*", "maintenance/*", "cli/*", "bugfix/*" ]
   pull_request:
     branches: [ master ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ log_cli = True
 log_cli_level = INFO
 norecursedirs = testdata
 testpaths = tests
+asyncio_mode=strict

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ freezegun>=1.1.0
 pyhanko-certvalidator==0.19.2
 requests>=2.0.0
 requests-mock>=1.8.0
-pytest-aiohttp>=0.3.0
+pytest-aiohttp~=1.0.4

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     tests_require=[
         'pytest>=6.1.1', 'pytz>=2020.1',
         'freezegun>=1.1.0', 'pyhanko-certvalidator==0.19.2',
-        'requests>=2.0.0', 'pytest-aiohttp>=0.3.0'
+        'requests>=2.0.0', 'pytest-aiohttp~=1.0.4'
     ],
     keywords="pki testing"
 )

--- a/tests/test_certs.py
+++ b/tests/test_certs.py
@@ -795,6 +795,7 @@ def test_keyset_templates_in_arch():
     assert algo == 'ed25519'
 
 
+@pytest.mark.asyncio
 async def test_pregenerated_cert():
     cfg = CertomancerConfig.from_file(
         'tests/data/with-pregenerated-cert.yml', 'tests/data'

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -125,6 +125,7 @@ def test_aia_ca_issuers(setup):
 
 
 @freeze_time('2020-11-01')
+@pytest.mark.asyncio
 @pytest.mark.parametrize('setup', [RSA_SETUP, DSA_SETUP, ECDSA_SETUP])
 async def test_validate(requests_mock, setup):
     setup.illusionist.register(requests_mock)


### PR DESCRIPTION
Update `pytest-aiohttp` and deal with the new strict `asyncio_mode` in pytest-asyncio for future-proofing.